### PR TITLE
Attempt to fix #22511: Deadlock in DataSet#beginUpdate

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapwithai/backend/MapWithAIDataUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapwithai/backend/MapWithAIDataUtils.java
@@ -349,7 +349,7 @@ public final class MapWithAIDataUtils {
                 final Lock lock = layer.getLock();
                 lock.lock();
                 try {
-                    mapWithAISet.mergeFrom(newData);
+                    mapWithAISet.update(() -> mapWithAISet.mergeFrom(newData));
                     GetDataRunnable.cleanup(mapWithAISet, null, null);
                 } finally {
                     lock.unlock();


### PR DESCRIPTION
This race occurs when
* MapWithAI is downloading and cleaning data *and*
* JOSM is performing a map paint

This attempts to fix the issue by getting a write lock *prior to* entering any synchronized methods in DataSet.

Signed-off-by: Taylor Smock <tsmock@meta.com>