### PR TITLE
PMTiles: invert y axis of tile coordinates

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapwithai/backend/BoundingBoxMapWithAIDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapwithai/backend/BoundingBoxMapWithAIDownloader.java
@@ -135,7 +135,7 @@ public class BoundingBoxMapWithAIDownloader extends BoundingBoxDownloader {
             final var tile1 = tileFromLatLonZoom(left, bottom, zoom);
             final var tile2 = tileFromLatLonZoom(right, top, zoom);
             return IntStream.rangeClosed(tile1.x, tile2.x)
-                    .mapToObj(x -> IntStream.rangeClosed(tile1.y, tile2.y).mapToObj(y -> new TileXYZ(x, y, zoom)))
+                    .mapToObj(x -> IntStream.rangeClosed(tile2.y, tile1.y).mapToObj(y -> new TileXYZ(x, y, zoom)))
                     .flatMap(stream -> stream);
         }
 


### PR DESCRIPTION
Hey @tsmock,

this is a small follow-up request to 4af7ac225ff2ecf8428a011cdfbbdf06cf5e079a. I think there’s a small logical error when calculating the XYZ tiles to download given the current viewport bounding box.

If the bounding box happens to span at least two rows of tiles, the generated list of tiles to download from `TileXYZ.tilesFromBBox()` is empty.

The y axis of XYZ tiles is oriented from north to south. When enumerating tiles for a given bounding box, the y coordinates have to be enumerated from north/top to south/bottom. Top/bottom have to be switched in the function.